### PR TITLE
do not show useless "records per page" options

### DIFF
--- a/lib/template/per-page-values.jsx
+++ b/lib/template/per-page-values.jsx
@@ -1,10 +1,13 @@
 module.exports = function(h, that) {
-var perpageValues = [];
- that.opts.perPageValues.map(function(value) {
-  var selected = that.limit==value;
-    perpageValues.push(<option value={value} selected={selected}>{value}</option>)
-  })
+  var perpageValues = [];
 
- return perpageValues;
+  that.opts.perPageValues.every(function(value) {
+    var isLastEntry = value >= that.count;
+    var selected = that.limit==value || (isLastEntry && that.limit>value);
+    perpageValues.push(<option value={value} selected={selected}>{value}</option>)
+    return !isLastEntry;
+  });
+
+  return perpageValues;
 
 }

--- a/lib/template/per-page.jsx
+++ b/lib/template/per-page.jsx
@@ -2,16 +2,20 @@ module.exports = function(h, that) {
 
   var perpageValues = require('./per-page-values.jsx')(h, that);
 
-  var id = 'VueTables__limit_' + that.id;
-  return  <div class="form-group form-inline pull-right VueTables__limit">
-        <label for={id}>{that.display('limit')}</label>
-        <select class="form-control"
-          name="limit"
-          value={that.limit}
-          on-change={that.setLimit.bind(that)}
-          id={id}
-          >
-          {perpageValues}
-        </select>
-      </div>
+  if (perpageValues.length > 1) {
+    var id = 'VueTables__limit_' + that.id;
+    return  <div class="form-group form-inline pull-right VueTables__limit">
+          <label for={id}>{that.display('limit')}</label>
+          <select class="form-control"
+            name="limit"
+            value={that.limit}
+            on-change={that.setLimit.bind(that)}
+            id={id}
+            >
+            {perpageValues}
+          </select>
+        </div>
+  }
+
+  return '';
 }


### PR DESCRIPTION
This PR solves parts of #14.

We shows only "records per page" options that are useful, i.e. for a total number of 23 records we hide the `100` option as the `50` option is just fine for that.
(Implementation note: `Array.prototype.every` can be short-circuited by returning `false` from the callback)

<strike>Note that we always considers the total number of unfiltered records. The reasoning as is follows:~~
* User wants to see many items, selects 100 records per page
* User enters some filter query, only a few items will be shown
* If we had hidden the larger options from the select box, it would automatically have jumped to a smaller value. But the selection would stay at the low value even after deleting the filter query, so the user would need to select 100 again.

Since the unfiltered total number of records is unknown in server mode, this functionality is limited to client mode only.</strike>

**Update:** Now considering the filtered total, see [my comment](https://github.com/matfish2/vue-tables-2/pull/15#issuecomment-257178451)