### PR TITLE
show a shorter count text if there is only one page

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -21,7 +21,7 @@
    skin:"table-striped table-bordered table-hover",
    columnsDisplay: {},
    texts:{
-   count:"Showing {from} to {to} out of {count} Records",
+   count:"Showing {from} to {to} of {count} records|{count} records|One record",
    filter:"Filter Results:",
     filterPlaceholder:"Search query",
     limit:"Records:",


### PR DESCRIPTION
Allow to use the feature introduced in https://github.com/matfish2/vue-pagination-2/pull/2

Related to #14

When releasing this, please make sure that the version dependency against `vue-pagination-2` is bumped to a version including my PR.