### PR TITLE
Fix for issue #36, Reset pagination with custom filter

### DIFF
--- a/lib/state/mutations.js
+++ b/lib/state/mutations.js
@@ -41,8 +41,10 @@ return merge.recursive(true,{
   [`${self.name}/SET_CUSTOM_FILTER`] (state, {filter, value}) {
     state.customQueries[filter] = value;
 
-    if (self.source=='server')
+    if (self.source=='server') {
+      state.page= 1;
       self.getData()
+    }
   },
   [`${self.name}/SET_LIMIT`] (state, limit) {
     state.page = 1;


### PR DESCRIPTION
Pagination isn't reset when filtering table with custom filters

See issue #36 