### PR TITLE
initFilters does nothing

### DIFF
--- a/lib/v-server-table.js
+++ b/lib/v-server-table.js
@@ -49,11 +49,11 @@ exports.install = function (Vue, globalOptions, useVuex, customTemplate) {
 
       }
 
-      this.getData(true).then(function (data) {
+      if (!this.vuex) {
+        this.customQueries = this.initCustomFilters();
+      }
 
-        if (!this.vuex) {
-          this.customQueries = this.initCustomFilters();
-        }
+      this.getData(true).then(function (data) {
 
         this.setData(this.opts.responseAdapter(data));
 


### PR DESCRIPTION
Currently, initFilters is only set up (if not using vuex) AFTER the initial data has already been fetched, thus defeating the entire point of it.

This PR simply moves that setup to before the initial data fetch.