### PR TITLE
Enable conditional rendering of table child rows

### DIFF
--- a/lib/template/rows.jsx
+++ b/lib/template/rows.jsx
@@ -21,7 +21,7 @@ module.exports = function(h, that) {
 
       rows.push(<tr class={rowClass} on-click={that.rowWasClicked.bind(that, row)}>{columns} </tr>);
 
-      if (that.opts.childRow) {
+      if (that.opts.childRow && this.rowsToggleState['row_' + row[rowKey]]) {
         let childRow = that.opts.childRow;
         let template = typeof childRow==='function'?
         childRow.apply(that, [h, row]):


### PR DESCRIPTION
Implements #59 

This is an easy performance improvement for those making heavy use of child rows. We simply defer the rendering of the child row until it is visible. This means that when sorting or filtering the table, we don't need to re-render child-rows for every visible row.