### PR TITLE
Add support for scoped templates

### DIFF
--- a/lib/template/rows.js
+++ b/lib/template/rows.js
@@ -13,8 +13,10 @@ module.exports = function(h, that) {
        columns.push(<td><span on-click={that.toggleChildRow.bind(that,row[rowKey])} class={`VueTables__child-row-toggler ` + that.childRowTogglerClass(row[rowKey])}></span></td>);
 
       that.allColumns.map(function(column) {
+          let rowTemplate = that.$scopedSlots && that.$scopedSlots[column];
+
           columns.push(<td>
-            {that.render(row, column, h)}
+            {rowTemplate ? rowTemplate({ row, column, index }) : that.render(row, column, h)}
         </td>)
       }.bind(that));
 


### PR DESCRIPTION
Hey.

This is a simple feature to reuse the vues' [$scopedSlots](https://vuejs.org/v2/guide/components.html#Scoped-Slots)  functionality for the templates.

Another way to add templates for the columns, that simplifies a lot of routine. You can actually specify any component to render within the <template> scope, if it's declared in the components property of the main component. 

```html
    <v-client-table :data="entries" :columns="['id', 'type']">
      <template slot="type" scope="props">
        <div>
          {{ props.row.type.title }}
        </div>
      </template>
    </v-client-table>
```