### PR TITLE
Make sorting aware of null object; also add sort as numeric column

### DIFF
--- a/lib/methods/get-sort-fn.js
+++ b/lib/methods/get-sort-fn.js
@@ -3,13 +3,27 @@ module.exports = function(column) {
 var ascending = this.orderBy.ascending;
 
 if (typeof this.opts.customSorting[column]=='undefined')
-  return function(a, b) {
+  return (a, b) => {
 
-    var aVal = a[column];
-    var bVal = b[column];
+    // Set to empty string if is null object
+    var aVal = a[column] == null ? '' : a[column];
+    var bVal = b[column] == null ? '' : b[column];
 
     if (typeof aVal==='string') aVal = aVal.toLowerCase();
     if (typeof bVal==='string') bVal = bVal.toLowerCase();
+
+    if (ascending)
+      return aVal >= bVal?1:-1;
+
+    return bVal >= aVal?1:-1;
+  };
+
+if (this.opts.customSorting[column] === 'numeric')
+  return (a, b) => {
+
+    // Cast to numbers if sort is set to 'numeric' for this column
+    var aVal = Number(a[column]);
+    var bVal = Number(b[column]);
 
     if (ascending)
       return aVal >= bVal?1:-1;

--- a/readme.md
+++ b/readme.md
@@ -455,6 +455,14 @@ customSorting:{
 }
 ```
 
+Additionally, if you know a particular column is numeric column, you can let the sorting method know so it can sort it as numeric values. For example the code below sort the `price` column as numeric column.
+
+```js
+customSorting:{
+    price: 'numeric'
+}
+```
+
 # Options
 
 Options are set in three layers, where the more particular overrides the more general.


### PR DESCRIPTION
This PR addresses the issue raised in #122 

Not entirely sure if it is your preferred way to config a column to be sorted as numeric column; but the idea is to cast them to numbers so you don't end up with 999 next to 99 next 9.