### PR TITLE
Update state when using the setFilter method

### DIFF
--- a/compiled/methods/set-filter.js
+++ b/compiled/methods/set-filter.js
@@ -13,6 +13,8 @@ module.exports = function (filter) {
     this.setPage(1, true);
   }
 
+  this.updateState('query', mergedFilter);
+
   this._setFiltersDOM(filter);
 
   if (this.source == 'server') {

--- a/lib/methods/set-filter.js
+++ b/lib/methods/set-filter.js
@@ -11,6 +11,8 @@ module.exports = function(filter) {
     this.setPage(1, true);
   }
 
+  this.updateState('query', mergedFilter);
+
   this._setFiltersDOM(filter);
 
   if (this.source == 'server') {


### PR DESCRIPTION
## Problem
When using the setFilter method, the state is not stored in local storage (when the `saveState: true` option is set.

## Solution
Use the `updateState` function in `set-filter.js`.
