### PR TITLE
In 2.5, the scope attribute has been deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ If you are using Vue 2.1.0 and above, you can use [scoped slots](https://vuejs.o
 
 ```vue
 <v-client-table :data="entries" :columns="['id', 'name' ,'age', 'edit']">
-  <template slot="edit" scope="props">
+  <template slot="edit" slot-scope="props">
     <div>
       <a class="fa fa-edit" :href="edit(props.row.id)"></a>
     </div>


### PR DESCRIPTION
https://gist.github.com/yyx990803/9bdff05e5468a60ced06c29c39114c6b#simplified-scoped-slots-usage