### PR TITLE
Improve immediate search when user press enter

### DIFF
--- a/lib/modules/text-filter.js
+++ b/lib/modules/text-filter.js
@@ -9,7 +9,12 @@
           var debouncedSearch = debounce(search, this.opts.debounce);
 
           var onKeyUp = function (e) {
-            e.keyCode === 13 ? debouncedSearch.flush() : debouncedSearch(...arguments);
+            if (e.keyCode === 13) {
+              debouncedSearch.clear();
+              search(...arguments);
+            } else {
+              debouncedSearch(...arguments);
+            }
           };
 
       return (column) => {


### PR DESCRIPTION
This PR fixes issue with immediate search after user press enter.

To reproduce this issue you should do this:
1. Set a pretty large debounce 
2. Type to field `#1` but don't press enter
3. Type to field `#2` and press enter 
4. Click to field `#1` and press enter
5. Filter should be updated according to input `#1` but it isn't
