### PR TITLE
disable highlighting for undefined values

### DIFF
--- a/lib/filters/highlight-matches.js
+++ b/lib/filters/highlight-matches.js
@@ -2,6 +2,8 @@ module.exports = function(value, column, h) {
 
   if (!this.opts.highlightMatches || this.filterableColumns.indexOf(column)===-1) return value;
 
+  if (typeof value === 'undefined') return value;
+
   var query = this.opts.filterByColumn?this.query[column]:this.query;
 
   if (!query) return value;


### PR DESCRIPTION
If some column is not defined for some of the rows which match search
filter, highlighting would convert empty values to text "undefined"
and highlight that. Added check disables highlighting of such fields
leaving the view empty for them.