### PR TITLE
Fixing characters disappearing on typing in server table filter

### DIFF
--- a/compiled/modules/normal-filter.js
+++ b/compiled/modules/normal-filter.js
@@ -16,9 +16,6 @@ module.exports = function (h) {
 
                 id: id
             },
-            domProps: {
-                'value': _this.query
-            },
             on: {
                 'keyup': _this.opts.debounce ? debounce(search, _this.opts.debounce) : search
             }


### PR DESCRIPTION
Resolves #521 

When using a server table if you entered a new query right after the debounce finished and the request was sent the letters would temporarily show up then disappear. I have useVuex set to false and can't confirm if this occurs when Vuex is used.

![search_bug](https://user-images.githubusercontent.com/36014115/48026988-92e76080-e115-11e8-8796-0c98d7117c88.gif)
(Note: I'm not hitting backspace or deleting those characters)

I think what is happening is this.query is getting set somewhere and since the value property is set to be equal to _this.query it resets it to what it was when the query was sent.

I'm not sure if there is a better way to solve this since I don't know the code base that well, but all the tests passed and I tried with both client and server tables and everything seemed to be working as normal.

This is what happens now when you repeat what I did in the first GIF.

![search_bug_fixed](https://user-images.githubusercontent.com/36014115/48031538-9a613680-e122-11e8-8402-65afd7bf9a27.gif)

Also, @matfish2 do I need to make a similar change in the lib/modules/normal-filter.js file?

