### PR TITLE
Fix inline style bootstrap 4

### DIFF
--- a/compiled/templates/default.js
+++ b/compiled/templates/default.js
@@ -15,7 +15,7 @@ module.exports = function (h, modules, classes, slots) {
 
   var genericFilter = this.hasGenericFilter ? h(
     'div',
-    { 'class': 'VueTables__search-field' },
+    { 'class': 'VueTables__search-field' + ' ' + classes.inline },
     [h(
       'label',
       {
@@ -27,7 +27,7 @@ module.exports = function (h, modules, classes, slots) {
 
   var perpage = perpageValues.length > 1 ? h(
     'div',
-    { 'class': 'VueTables__limit-field' },
+    { 'class': 'VueTables__limit-field' + ' ' + classes.inline },
     [h(
       'label',
       { 'class': classes.label, attrs: { 'for': perpageId }


### PR DESCRIPTION
For bootstrap 4, the inline class has to be nested.