### PR TITLE
fix(resizeable-columns): cleanup document listeners on destroy

### DIFF
--- a/lib/helpers/resizeable-columns.js
+++ b/lib/helpers/resizeable-columns.js
@@ -16,6 +16,8 @@ module.exports = function(table, hasChildRow, isChildRowTogglerFirst, resizeable
   var till =
     hasChildRow && !isChildRowTogglerFirst ? cols.length - 2 : cols.length;
 
+  var documentListeners = []
+
   for (; i < till; i++) {
     var div = createDiv(tableHeight);
     div.className = "resize-handle";
@@ -49,7 +51,7 @@ module.exports = function(table, hasChildRow, isChildRowTogglerFirst, resizeable
       e.target.style.borderRight = "";
     });
 
-    document.addEventListener("mousemove", function(e) {
+    function onMouseMove(e) {
       if (curCol) {
         var diffX = e.pageX - pageX;
 
@@ -57,9 +59,9 @@ module.exports = function(table, hasChildRow, isChildRowTogglerFirst, resizeable
 
         curCol.style.width = curColWidth + diffX + "px";
       }
-    });
+    }
 
-    document.addEventListener("mouseup", function(e) {
+    function onMouseUp(e) {
       if (e.target.nodeName==='INPUT') return;
 
       e.preventDefault();
@@ -69,7 +71,16 @@ module.exports = function(table, hasChildRow, isChildRowTogglerFirst, resizeable
       pageX = undefined;
       nxtColWidth = undefined;
       curColWidth = undefined;
-    });
+    }
+
+    document.addEventListener("mousemove", onMouseMove);
+
+    document.addEventListener("mouseup", onMouseUp);
+
+    documentListeners.push(
+      { event: "mousemove", handler: onMouseMove },
+      { event: "mouseup", handler: onMouseUp }
+    );
   }
 
   function createDiv(height) {
@@ -97,4 +108,12 @@ module.exports = function(table, hasChildRow, isChildRowTogglerFirst, resizeable
   function getStyleVal(elm, css) {
     return window.getComputedStyle(elm, null).getPropertyValue(css);
   }
+
+  function removeDocumentListeners() {
+    documentListeners.forEach(function(listener) {
+      document.removeEventListener(listener.event, listener.handler);
+    });
+  }
+
+  return removeDocumentListeners;
 };

--- a/lib/v-client-table.js
+++ b/lib/v-client-table.js
@@ -65,12 +65,14 @@ exports.install = function(
       this._setFiltersDOM(this.query);
 
       if (this.opts.resizableColumns) {
-        resizableColumns(
+        var removeResizableListeners = resizableColumns(
           this.$el.querySelector("table"),
           this.hasChildRow,
           this.opts.childRowTogglerFirst,
           this.opts.resizableColumns
         );
+
+        this.$once('hook:beforeDestroy', removeResizableListeners);
       }
 
       this._setColumnsDropdownCloseListener();

--- a/lib/v-server-table.js
+++ b/lib/v-server-table.js
@@ -88,12 +88,14 @@ exports.install = function(
         this._setFiltersDOM(this.query);
 
         if (this.opts.resizableColumns) {
-          resizableColumns(
+          var removeResizableListeners = resizableColumns(
             this.$el.querySelector("table"),
             this.hasChildRow,
             this.opts.childRowTogglerFirst,
             this.opts.resizableColumns
           );
+
+          this.$once('hook:beforeDestroy', removeResizableListeners);
         }
 
         this._setColumnsDropdownCloseListener();


### PR DESCRIPTION
If `resizableColumns` is set to true we should clear all document listeners after table is destroyed.