### PR TITLE
Expose customQueries to ServerTable for easier manipulations

### DIFF
--- a/compiled/components/VtServerTable.js
+++ b/compiled/components/VtServerTable.js
@@ -50,6 +50,16 @@ var _default2 = {
       }
     }
   },
+  computed: {
+    customQueries: {
+      get: function get() {
+        return this.$refs.table.customQueries;
+      },
+      set: function set(val) {
+        this.$refs.table.customQueries = val;
+      }
+    }
+  },
   methods: {
     refresh: function refresh() {
       this.$refs.table.refresh();

--- a/lib/components/VtServerTable.jsx
+++ b/lib/components/VtServerTable.jsx
@@ -36,6 +36,16 @@ export default {
             }
         }
     },
+    computed: {
+      customQueries: {
+        get() {
+          return this.$refs.table.customQueries;
+        },
+        set(val) {
+          this.$refs.table.customQueries = val;
+        }
+      }
+    },
     methods: {
         refresh() {
           this.$refs.table.refresh();

--- a/test/server/custom-queries.spec.js
+++ b/test/server/custom-queries.spec.js
@@ -1,0 +1,23 @@
+describe(suite + ": Custom Queries", () => {
+  it('exposes the Renderless ServerTable', () => {
+    createWrapper({
+      debounce: 0,
+      customFilters: [
+        'foo'
+      ],
+      initFilters: {
+        foo: 'bar'
+      }
+    })
+
+    expect(vm().customQueries).toEqual({
+      foo: 'bar'
+    })
+
+    expect(vm().customQueries).toEqual(vm().$refs.table.customQueries)
+
+    vm().customQueries.foo = 'baz'
+
+    expect(vm().$refs.table.customQueries.foo).toEqual('baz')
+  })
+})


### PR DESCRIPTION
I was facing an issue when I wanted to apply multiple changes at once on the registered `customFilters` without doing multiple HTTP calls.

To make it work in `2.0.0`, the implementing component needed to look deep into the inner-structure of the `ServerTable`

**Before:**
```javascript
applyMultipleFilters(incomingFilters) {
  this.$refs.myTable.$refs.table.customQueries = {
    ...this.$refs.myTable.$refs.table.customQueries,
    ...incomingFilters
  }
  this.$refs.myTable.refresh()
```

With this PR, the call gets simplified by exposing the `customQueries` to the upper ServerTable. The implementing component now doesn't have to know the inner-structure as he can apply changes on the `customQueries` directly and calling `refresh()` to make the additional HTTP Call.

**After:**
```javascript
applyMultipleFilters(incomingFilters) {
  this.$refs.myTable.customQueries = {
    ...this.$refs.myTable.customQueries,
    ...incomingFilters
  }
  this.$refs.myTable.refresh()
```
